### PR TITLE
exclude network from hardening

### DIFF
--- a/src/core/jrs-resume.js
+++ b/src/core/jrs-resume.js
@@ -365,7 +365,7 @@ Definition of the JRSResume class.
           if( typeof sub === 'string' || sub instanceof String ) {
             if( _.contains(['skills','url','website','startDate','endDate',
               'releaseDate','date','phone','email','address','postalCode',
-              'city','country','region'], key) )
+              'city','country','region', 'network'], key) )
               return;
             if( key === 'summary' )
               obj[key] = HD( obj[key] );


### PR DESCRIPTION
Hardening the network breaks at least the Kendall Theme and furthermore is not necessary for this field.

See LinuxBozo/jsonresume-theme-kendall#9
